### PR TITLE
Remove custom 404 page declaration #21

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -24,17 +24,6 @@ Resources:
       AccessControl: PublicRead
       WebsiteConfiguration:
         IndexDocument: index.html
-        ErrorDocument: error/404/index.html
-        RoutingRules:
-          - RoutingRuleCondition:
-              HttpErrorCodeReturnedEquals: '404'
-              KeyPrefixEquals: /
-            RedirectRule:
-              HostName: !Sub
-                - '${SubDomainName}.${HostedZoneName}.'
-                - SubDomainName: !Ref SubDomainName
-                  HostedZoneName: !Ref HostedZoneName
-              ReplaceKeyPrefixWith: error/404/
   WebsiteCloudFront:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -52,10 +41,6 @@ Resources:
             - '${SubDomainName}.${HostedZoneName}'
             - SubDomainName: !Ref SubDomainName
               HostedZoneName: !Ref HostedZoneName 
-        CustomErrorResponses:
-          - ErrorCode: 403
-            ResponseCode: 404
-            ResponsePagePath: '/error/404/index.html'
         DefaultCacheBehavior:
           TargetOriginId: S3Origin
           ViewerProtocolPolicy: redirect-to-https


### PR DESCRIPTION
I cross-checked the website and docs repos and how they behave.

- The docs repo has a proper 404.html file, fitting the theme, and it's served for invalid URLs.
- The website repo has nothing relevant in its stack.yaml, and AWS is serving a default 404 response.

For the sake of simplicity, I copied the second version. I believe it should fix the 403 errors that are caused by the missing error document. But I have no means to test it.