### PR TITLE
Complete overhaul of API docs generation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @0xTim @gwynne

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -5,27 +5,7 @@ on:
     types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
 
 jobs:
-  setup_matrix_input:
-    runs-on: ubuntu-latest
-
-    steps:
-      - id: set-matrix 
-        run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name') || output=""
-
-          echo '======================'
-          echo 'Process incoming data'
-          echo '======================'
-          json=$(echo $output | sed 's/"\s"/","/g')
-          echo $json
-          echo "::set-output name=matrix::$(echo $json)"
-    outputs:
-      issueTags: ${{ steps.set-matrix.outputs.matrix }}
-      
-  Manage_project_issues:
-    needs: setup_matrix_input
-    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
-    with:
-      labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}
-    secrets: 
-      PROJECT_BOARD_AUTOMATION_PAT: "${{ secrets.PROJECT_BOARD_AUTOMATION_PAT }}"
+  update_project_boards:
+    name: Update project boards
+    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@reusable-workflows
+    secrets: inherit

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Qutheory, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/theme-settings.json
+++ b/theme-settings.json
@@ -1,5 +1,4 @@
 {
-    "meta": {},
     "theme": {
         "aside": {
             "border-radius": "6px",
@@ -22,11 +21,8 @@
                 "dark": "rgb(20, 20, 22)",
                 "light": "rgb(255, 255, 255)"
             },
-            "documentation-intro-fill": "var(--color-fill)"
+            "documentation-intro-fill": "radial-gradient(circle at top, #ccc 15%, #111 100%)",
         },
-        "typography": {
-            "html-font": ""
-        }
     },
     "features": {
         "quickNavigation": {


### PR DESCRIPTION
Completely rebuilds the API docs generator script to: 

- Use the DocC generator plugin instead of doing it manually.
- Inject the plugin dependency if needed.
- Uses the plugin's "disable indexing to make the docs smaller, if you're not reading them in Xcode" option.
- Uses the plugin's experimental "don't generate a bunch of crud for compiler-synthesized boilerplate" option.
- Not overwrite theme settings for packages that have their own.
- Not hardcode the DocC catalog name.

That's not the kicker, though.

The kicker is, this whole 140-line Swift script can be rewritten as a 20-line Bash script that does all the same crud:
```bash
#!/usr/bin/env bash -e

plugin='.package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.3.0"),'
package=$1; echo "$2" | IFS=',' read -r -a modules
rm -rf ./public ./.build; mkdir -p ./public
if [[ -z "$(fgrep '.package(url: "https://github.com/apple/swift-docc-plugin' Package.swift)" ]]; then
     sed -i '' -E -e "1,/dependencies: \[/s|dependencies: \[|&\n${plugin}\n|1" Package.swift
fi
for module in ${modules[@]}; do
    [[ $(echo Sources/"${module}"/*.docc | wc -w) -eq 1 ]] || { \
        echo "Missing or multiple DocC catalogs in ${module}"; exit 1; }
    cp -n theme-settings.json Sources/"${module}"/*.docc
    swift package --allow-writing-to-directory ./public \
        generate-documentation --target "${module}" \
        --disable-indexing --experimental-skip-synthesized-symbols \
        --fallback-display-name "${module}" \
        --fallback-bundle-identifier "codes.vapor.${package@L}.${module@L}" \
        --fallback-bundle-version 1.0.0 \
        --transform-for-static-hosting --hosting-base-path "/${module@L}" \
        --output-path "./public/${module@L}"
done
```
(Note: I have tested the Swift version. I have _not_ tested the Bash version.)

Also here, have a fix for the theme blanking out summary text and the missing license and code owners files for this repo 😛